### PR TITLE
Add ict services section to main page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -43,13 +43,15 @@
         {{ with .Site.GetPage "/ict-services" }}
         <h2 class="tc f2 fw7 ma0 mb3" style="color: #008080;">{{ .Title }}</h2>
             {{ partial "little-icons" . }}
+        {{ end }}
+    </div>
+</section>
 
 <section id="ict-security-section">
     <div class="container">
         {{ with .Site.GetPage "/ict-security" }}
        <h2 class="tc f2 fw7 ma0 mb3" style="color: #008080;">{{ .Title }}</h2> 
             {{ partial "img-right" . }}
-
         {{ end }}
     </div>
 </section>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,6 +37,16 @@
 </article>
 {{ end }}
 
+<!-- Add ict services section to main page -->
+<section id="ict-services-section">
+    <div class="container">
+        {{ with .Site.GetPage "/ict-services" }}
+        <h2 class="tc pv3">{{ .Title }}</h2>
+            {{ partial "little-icons" . }}
+        {{ end }}
+    </div>
+</section>
+
 <div class="center mt2 tc f4 f5-ns fw4 pt4-ns ph5-ns lh-title" style="color:{{ $.Param "middle_title_color_code" | default "#555555" }};">
 {{ .Params.final_message }}
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,7 +41,7 @@
 <section id="ict-services-section">
     <div class="container">
         {{ with .Site.GetPage "/ict-services" }}
-        <h2 class="tc pv3">{{ .Title }}</h2>
+        <h2 class="tc f2 fw7 ma0 mb3" style="color: #008080;">{{ .Title }}</h2>
             {{ partial "little-icons" . }}
         {{ end }}
     </div>


### PR DESCRIPTION
Тепер на головній сторінці можна побачити контент з /services/ict-services/, кнопки навігації працюють як і раніше.